### PR TITLE
Add vector clipboard chat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This repository contains a simple Garry's Mod addon. The addon adds a chat
 command that allows players to copy their current position to the system
-clipboard. Use `/vector <precision>` in chat to copy the player's position as a
-`Vector` string with the specified number of decimal places (default is 2).
+clipboard. Use `/vector <precision>` or `/vector<precision>` in chat to copy the
+player's position as a `Vector` string with the specified number of decimal
+places. If no precision is supplied, the addon defaults to 2 decimal places.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Fyntric-Framework
+
+This repository contains a simple Garry's Mod addon. The addon adds a chat
+command that allows players to copy their current position to the system
+clipboard. Use `/vector <precision>` in chat to copy the player's position as a
+`Vector` string with the specified number of decimal places (default is 2).
+

--- a/lua/autorun/client/vectorclipboard.lua
+++ b/lua/autorun/client/vectorclipboard.lua
@@ -1,42 +1,28 @@
 --[[
     Vector Clipboard Addon
-    When the local player types "/vector <precision>" in chat, this addon copies
-    the player's current position vector to the clipboard with the requested
-    number of decimal places (default 2 if not specified).
+    When the local player types "/vector <precision>" or "/vector<precision>"
+    in chat, this addon copies the player's current position vector to the
+    clipboard. Precision controls the number of decimal places (default is 2).
 ]]
 
-local function copyVectorToClipboard(msg)
-    -- Only react to the local player's messages
-    if msg ~= LocalPlayer() then return end
+hook.Add("OnPlayerChat", "VectorClipboardCopy", function(ply, text)
+    if ply ~= LocalPlayer() then return end
 
-    local text = msg
-    local prefix = string.match(text, "^/vector")
-    if not prefix then return end
+    local cmd = string.lower(text)
+    local precisionStr = cmd:match("^/vector%s*(%d*)$")
+    if not precisionStr then return end
 
-    -- Extract precision number after the command
-    local precision = tonumber(text:match("^/vector%s+(%d+)$")) or 2
-
-    local pos = LocalPlayer():GetPos()
+    local precision = tonumber(precisionStr) or 2
+    local pos = ply:GetPos()
     local fmt = string.format("%%.%df", precision)
     local vectorStr = string.format("Vector(%s, %s, %s)",
         string.format(fmt, pos.x),
         string.format(fmt, pos.y),
         string.format(fmt, pos.z))
 
-    -- Copy to clipboard on the client
     SetClipboardText(vectorStr)
     chat.AddText(Color(0,255,0), "Copied position: ", vectorStr)
 
     return true -- block message from chat
-end
-
-hook.Add("OnPlayerChat", "VectorClipboardCopy", function(ply, text)
-    if ply ~= LocalPlayer() then return end
-    local cmd = string.lower(text)
-    if cmd:StartWith("/vector") then
-        -- Build message with the same text to handle precision
-        copyVectorToClipboard(text)
-        return true
-    end
 end)
 

--- a/lua/autorun/client/vectorclipboard.lua
+++ b/lua/autorun/client/vectorclipboard.lua
@@ -1,0 +1,42 @@
+--[[
+    Vector Clipboard Addon
+    When the local player types "/vector <precision>" in chat, this addon copies
+    the player's current position vector to the clipboard with the requested
+    number of decimal places (default 2 if not specified).
+]]
+
+local function copyVectorToClipboard(msg)
+    -- Only react to the local player's messages
+    if msg ~= LocalPlayer() then return end
+
+    local text = msg
+    local prefix = string.match(text, "^/vector")
+    if not prefix then return end
+
+    -- Extract precision number after the command
+    local precision = tonumber(text:match("^/vector%s+(%d+)$")) or 2
+
+    local pos = LocalPlayer():GetPos()
+    local fmt = string.format("%%.%df", precision)
+    local vectorStr = string.format("Vector(%s, %s, %s)",
+        string.format(fmt, pos.x),
+        string.format(fmt, pos.y),
+        string.format(fmt, pos.z))
+
+    -- Copy to clipboard on the client
+    SetClipboardText(vectorStr)
+    chat.AddText(Color(0,255,0), "Copied position: ", vectorStr)
+
+    return true -- block message from chat
+end
+
+hook.Add("OnPlayerChat", "VectorClipboardCopy", function(ply, text)
+    if ply ~= LocalPlayer() then return end
+    local cmd = string.lower(text)
+    if cmd:StartWith("/vector") then
+        -- Build message with the same text to handle precision
+        copyVectorToClipboard(text)
+        return true
+    end
+end)
+


### PR DESCRIPTION
## Summary
- add simple README with usage instructions
- add a client autorun script that copies player position on `/vector <precision>`

## Testing
- `luac -p lua/autorun/client/vectorclipboard.lua`

------
https://chatgpt.com/codex/tasks/task_e_6885d5d8e0fc8322810a4ae0cb10049c