### PR TITLE
Add Star Wars NPC spawn script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# Fyntric-Framework
+# Fyntric Framework
+
+This repository contains example files for Garry's Mod addons.
+
+## Star Wars NPC
+
+The `lua/autorun/starwars_npc.lua` script spawns a custom Star Wars NPC at a fixed location using the playermodel `models/aussiwozzi/cgi/base/212th_arc.mdl`.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository contains example files for Garry's Mod addons.
 
 ## Star Wars NPC
 
-The `lua/autorun/starwars_npc.lua` script spawns a custom Star Wars NPC at a fixed location using the playermodel `models/aussiwozzi/cgi/base/212th_arc.mdl`.
+The `lua/autorun/starwars_npc.lua` script spawns a custom Star Wars NPC at a fixed location using the playermodel `models/aussiwozzi/cgi/base/212th_arc.mdl`. The NPC is frozen in place so it won't move around.

--- a/lua/autorun/starwars_npc.lua
+++ b/lua/autorun/starwars_npc.lua
@@ -2,17 +2,22 @@
 
 if SERVER then
     hook.Add("InitPostEntity", "SpawnFrozenStarWarsNPC", function()
+        -- Position and orientation for the NPC
         local pos = Vector(-10322.2559, -848.5197, -6086.9688)
+        local ang = Angle(0, 0, 0)
 
         local npc = ents.Create("npc_citizen")
         if not IsValid(npc) then return end
 
         npc:SetModel("models/aussiwozzi/cgi/base/212th_arc.mdl")
         npc:SetPos(pos)
+        npc:SetAngles(ang)
         npc:Spawn()
 
-        -- Prevent the NPC from moving
+        -- Keep the NPC completely frozen
         npc:CapabilitiesClear()
+        npc:SetNPCState(NPC_STATE_SCRIPT)
+        npc:SetSchedule(SCHED_IDLE_STAND)
         npc:SetMoveType(MOVETYPE_NONE)
     end)
 end

--- a/lua/autorun/starwars_npc.lua
+++ b/lua/autorun/starwars_npc.lua
@@ -1,0 +1,18 @@
+-- Spawns a frozen Star Wars NPC at the specified location
+
+if SERVER then
+    hook.Add("InitPostEntity", "SpawnFrozenStarWarsNPC", function()
+        local pos = Vector(-10322.2559, -848.5197, -6086.9688)
+
+        local npc = ents.Create("npc_citizen")
+        if not IsValid(npc) then return end
+
+        npc:SetModel("models/aussiwozzi/cgi/base/212th_arc.mdl")
+        npc:SetPos(pos)
+        npc:Spawn()
+
+        -- Prevent the NPC from moving
+        npc:CapabilitiesClear()
+        npc:SetMoveType(MOVETYPE_NONE)
+    end)
+end


### PR DESCRIPTION
## Summary
- add README contents
- add example addon to spawn a frozen Star Wars NPC with playermodel

## Testing
- `luac -p lua/autorun/starwars_npc.lua`

------
https://chatgpt.com/codex/tasks/task_e_6885da3f2f00832295483116258496c3